### PR TITLE
⬆ Define integration type

### DIFF
--- a/custom_components/signal_ecogaz/manifest.json
+++ b/custom_components/signal_ecogaz/manifest.json
@@ -8,6 +8,7 @@
   "documentation": "https://github.com/kamaradclimber/signal-ecogaz",
   "issue_tracker": "https://github.com/kamaradclimber/signal-ecogaz/issues",
   "codeowners": ["@kamaradclimber"],
+  "integration_type": "device",
   "name": "Signal Ecogaz",
   "config_flow": true,
   "version": "0.1.0"

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,6 @@
 {
   "name": "Signal Ecogaz",
   "render_readme": true,
-  "country": "fr"
+  "country": "fr",
+  "homeassistant": "2022.11"
 }


### PR DESCRIPTION
This integration does not even define a single "device" but there is no better option apparently

This requires latest version of homeassistant

Change-Id: I9289c55b343954cddd6a01f5ab348dce8906a30a