### PR TITLE
 infos ne sont pas jusque J+4 mais J+5

### DIFF
--- a/custom_components/signal_ecogaz/__init__.py
+++ b/custom_components/signal_ecogaz/__init__.py
@@ -93,7 +93,7 @@ class EcoGazAPICoordinator(DataUpdateCoordinator):
                 )
             _LOGGER.debug("Starting collecting data")
             async with aiohttp.ClientSession() as session:
-                async with session.get('https://odre.opendatasoft.com/api/records/1.0/search/?dataset=signal-ecogaz&q=&facet=gas_day&rows=30') as api_result:
+                async with session.get('https://odre.opendatasoft.com/api/records/1.0/search/?dataset=signal-ecogaz&q=&facet=gas_day&sort=gas_day&rows=5') as api_result:
 
                     _LOGGER.debug(f"data received, status code: {api_result.status}")
                     if api_result.status != 200:

--- a/custom_components/signal_ecogaz/__init__.py
+++ b/custom_components/signal_ecogaz/__init__.py
@@ -93,7 +93,7 @@ class EcoGazAPICoordinator(DataUpdateCoordinator):
                 )
             _LOGGER.debug("Starting collecting data")
             async with aiohttp.ClientSession() as session:
-                async with session.get('https://odre.opendatasoft.com/api/records/1.0/search/?dataset=signal-ecogaz&q=&facet=gas_day&sort=gas_day&rows=6') as api_result:
+                async with session.get('https://odre.opendatasoft.com/api/records/1.0/search/?dataset=signal-ecogaz&q=&facet=gas_day&sort=gas_day&rows=30') as api_result:
 
                     _LOGGER.debug(f"data received, status code: {api_result.status}")
                     if api_result.status != 200:

--- a/custom_components/signal_ecogaz/__init__.py
+++ b/custom_components/signal_ecogaz/__init__.py
@@ -93,7 +93,7 @@ class EcoGazAPICoordinator(DataUpdateCoordinator):
                 )
             _LOGGER.debug("Starting collecting data")
             async with aiohttp.ClientSession() as session:
-                async with session.get('https://odre.opendatasoft.com/api/records/1.0/search/?dataset=signal-ecogaz&q=&facet=gas_day&sort=gas_day&rows=5') as api_result:
+                async with session.get('https://odre.opendatasoft.com/api/records/1.0/search/?dataset=signal-ecogaz&q=&facet=gas_day&sort=gas_day&rows=6') as api_result:
 
                     _LOGGER.debug(f"data received, status code: {api_result.status}")
                     if api_result.status != 200:


### PR DESCRIPTION
Pour corriger l'erreur suivante dans la log

En fait les infos ne sont pas jusque J+4 mais J+5, du (rows=5 est insuffisant) j'ai remis ce que tu vais mis au départ &rows=30, çà laisse de la marge si l'API change :)

This error originated from a custom integration.

Logger: homeassistant
Source: custom_components/signal_ecogaz/__init__.py:223
Integration: Signal Ecogaz (documentation, issues)
First occurred: 2:44:35 PM (1 occurrences)
Last logged: 2:44:35 PM

Error doing job: Task exception was never retrieved
Traceback (most recent call last):
  File "/config/custom_components/signal_ecogaz/__init__.py", line 215, in _find_ecogaz_level
    ecogaz_data = next(
StopIteration

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 151, in _handle_refresh_interval
    await self._async_refresh(log_failures=True, scheduled=True)
  File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 283, in _async_refresh
    self.async_update_listeners()
  File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 110, in async_update_listeners
    update_callback()
  File "/config/custom_components/signal_ecogaz/__init__.py", line 168, in _handle_coordinator_update
    ecogaz_level = self._find_ecogaz_level()
  File "/config/custom_components/signal_ecogaz/__init__.py", line 223, in _find_ecogaz_level
    raise RuntimeError(
RuntimeError: Unable to find ecogaz level for 2022-12-03
